### PR TITLE
Create and list `users`

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,4 +1,8 @@
-import { InternalServerError, MethodNotAllowedError } from "infra/errors";
+import {
+  InternalServerError,
+  MethodNotAllowedError,
+  ValidationError,
+} from "infra/errors";
 
 function onNoMatchHandler(_, res) {
   const publicErrorObject = new MethodNotAllowedError();
@@ -6,6 +10,10 @@ function onNoMatchHandler(_, res) {
 }
 
 function onErrorHandler(error, _, res) {
+  if (error instanceof ValidationError) {
+    return res.status(error.statusCode).json(error);
+  }
+
   const publicErrorObject = new InternalServerError({
     cause: error,
     statusCode: error.statusCode,

--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,6 +1,7 @@
 import {
   InternalServerError,
   MethodNotAllowedError,
+  NotFoundError,
   ValidationError,
 } from "infra/errors";
 
@@ -10,7 +11,7 @@ function onNoMatchHandler(_, res) {
 }
 
 function onErrorHandler(error, _, res) {
-  if (error instanceof ValidationError) {
+  if (error instanceof ValidationError || error instanceof NotFoundError) {
     return res.status(error.statusCode).json(error);
   }
 

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -56,3 +56,23 @@ export class ServiceError extends Error {
     };
   }
 }
+
+export class ValidationError extends Error {
+  constructor({ cause, message, action }) {
+    super(message || "Um erro de validação ocorreu.", {
+      cause,
+    });
+    this.name = "ValidationError";
+    this.action = action || "Ajuste os dados enviados e tente novamente.";
+    this.statusCode = 400;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -76,3 +76,25 @@ export class ValidationError extends Error {
     };
   }
 }
+
+export class NotFoundError extends Error {
+  constructor({ cause, message, action }) {
+    super(message || "Não foi possível encontrar este recurso no sistema.", {
+      cause,
+    });
+    this.name = "NotFoundError";
+    this.action =
+      action ||
+      "Verifique se os parâmetros enviados na consulta estão corretos.";
+    this.statusCode = 404;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}

--- a/infra/migrations/1739564186540_teste-migration.js
+++ b/infra/migrations/1739564186540_teste-migration.js
@@ -1,8 +1,0 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable camelcase */
-
-exports.shorthands = undefined;
-
-exports.up = (pgm) => {};
-
-exports.down = (pgm) => {};

--- a/infra/migrations/1745969246261_create-users.js
+++ b/infra/migrations/1745969246261_create-users.js
@@ -1,0 +1,39 @@
+exports.up = (pgm) => {
+  pgm.createTable("users", {
+    id: {
+      type: "uuid",
+      primaryKey: true,
+      default: pgm.func("gen_random_uuid()"),
+    },
+    // for reference, GitHub limits username to 39 characters.
+    username: {
+      type: "varchar(30)",
+      notNull: true,
+      unique: true,
+    },
+    // why 254 in length? https://stackoverflow.com/a/1199238
+    email: {
+      type: "varchar(254)",
+      notNull: true,
+      unique: true,
+    },
+    // why 60 in length? https://www.npmjs.com/package/bcrypt#hash-info
+    password: {
+      type: "varchar(60)",
+      notNull: true,
+    },
+    // why timestamp with timezone? https://justatheory.com/2012/04/postgres-use-timestamptz/
+    created_at: {
+      type: "timestamptz",
+      notNull: true,
+      default: pgm.func("timezone('utc', now())"),
+    },
+    updated_at: {
+      type: "timestamptz",
+      notNull: true,
+      default: pgm.func("timezone('utc', now())"),
+    },
+  });
+};
+
+exports.down = false;

--- a/models/migrator.js
+++ b/models/migrator.js
@@ -7,7 +7,7 @@ const defaultMigrationOptions = {
   dryRun: true,
   dir: resolve("infra", "migrations"),
   direction: "up",
-  verbose: true,
+  log: () => {},
   migrationsTable: "pgmigrations",
 };
 

--- a/models/user.js
+++ b/models/user.js
@@ -1,0 +1,78 @@
+import database from "infra/database";
+import { ValidationError } from "infra/errors";
+
+async function create(userInputValues) {
+  await validateUniqueEmail(userInputValues.email);
+  await validateUniqueUsername(userInputValues.username);
+
+  const newUser = await runInsertQuery(userInputValues);
+  return newUser;
+
+  async function validateUniqueEmail(email) {
+    const result = await database.query({
+      text: `
+        SELECT  
+          email
+        FROM
+          users
+        WHERE
+          LOWER(email) = LOWER($1)
+        ;`,
+      values: [email],
+    });
+
+    if (result.rowCount > 0) {
+      throw new ValidationError({
+        message: "O email informado já está sendo utilizado.",
+        action: "Utilize outro email para realizar o cadastro.",
+      });
+    }
+  }
+
+  async function validateUniqueUsername(username) {
+    const result = await database.query({
+      text: `
+        SELECT  
+          username
+        FROM
+          users
+        WHERE
+          LOWER(username) = LOWER($1)
+        ;`,
+      values: [username],
+    });
+
+    if (result.rowCount > 0) {
+      throw new ValidationError({
+        message: "O username informado já está sendo utilizado.",
+        action: "Utilize outro username para realizar o cadastro.",
+      });
+    }
+  }
+
+  async function runInsertQuery(userInputValues) {
+    const result = await database.query({
+      text: `
+        INSERT INTO 
+          users (username, email, password) 
+        VALUES 
+          ($1, $2, $3)
+        RETURNING
+          *
+        ;`,
+      values: [
+        userInputValues.username,
+        userInputValues.email,
+        userInputValues.password,
+      ],
+    });
+
+    return result.rows[0];
+  }
+}
+
+const user = {
+  create,
+};
+
+export default user;

--- a/models/user.js
+++ b/models/user.js
@@ -1,5 +1,34 @@
 import database from "infra/database";
-import { ValidationError } from "infra/errors";
+import { NotFoundError, ValidationError } from "infra/errors";
+
+async function findOneByUsername(username) {
+  const newUser = await runSelectQuery(username);
+  return newUser;
+
+  async function runSelectQuery(username) {
+    const result = await database.query({
+      text: `
+        SELECT  
+          *
+        FROM
+          users
+        WHERE
+          LOWER(username) = LOWER($1)
+        LIMIT
+          1
+        ;`,
+      values: [username],
+    });
+
+    if (result.rowCount <= 0) {
+      throw new NotFoundError({
+        message: "O username informado não foi encontrado no sistema.",
+        action: "Verifique se o username está digitado corretamente.",
+      });
+    }
+    return result.rows[0];
+  }
+}
 
 async function create(userInputValues) {
   await validateUniqueEmail(userInputValues.email);
@@ -73,6 +102,7 @@ async function create(userInputValues) {
 
 const user = {
   create,
+  findOneByUsername,
 };
 
 export default user;

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "pg": "8.12.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
-        "swr": "2.2.5"
+        "swr": "2.2.5",
+        "uuid": "11.1.0"
       },
       "devDependencies": {
         "@commitlint/cli": "19.4.0",
@@ -12460,6 +12461,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "pg": "8.12.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "swr": "2.2.5"
+    "swr": "2.2.5",
+    "uuid": "11.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "19.4.0",

--- a/pages/api/v1/users/[username]/index.js
+++ b/pages/api/v1/users/[username]/index.js
@@ -1,0 +1,15 @@
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import user from "models/user";
+
+const router = createRouter();
+
+router.get(getHandler);
+
+export default router.handler(controller.errorHandlers);
+
+async function getHandler(req, res) {
+  const username = req.query.username;
+  const userFound = await user.findOneByUsername(username);
+  return res.status(200).json(userFound);
+}

--- a/pages/api/v1/users/index.js
+++ b/pages/api/v1/users/index.js
@@ -1,0 +1,17 @@
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import user from "models/user";
+
+const router = createRouter();
+
+router.post(postHandler);
+
+export default router.handler(controller.errorHandlers);
+
+async function postHandler(req, res) {
+  const userInputValues = req.body;
+
+  const newUser = await user.create(userInputValues);
+
+  return res.status(201).json(newUser);
+}

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -1,0 +1,91 @@
+import { version as uuidVersion } from "uuid";
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("GET /api/v1/users/[username]", () => {
+  describe("Anonymous user", () => {
+    test("With exact case match", async () => {
+      await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "MesmoCase",
+          email: "MesmoCase@curso.dev",
+          password: "123456",
+        }),
+      });
+
+      const respGet = await fetch(
+        "http://localhost:3000/api/v1/users/MesmoCase",
+      );
+      expect(respGet.status).toBe(200);
+
+      const respGetBody = await respGet.json();
+      expect(respGetBody).toEqual({
+        id: respGetBody.id,
+        username: "MesmoCase",
+        email: "MesmoCase@curso.dev",
+        password: "123456",
+        created_at: respGetBody.created_at,
+        updated_at: respGetBody.updated_at,
+      });
+      expect(uuidVersion(respGetBody.id)).toBe(4);
+      expect(Date.parse(respGetBody.created_at)).not.toBeNaN();
+      expect(Date.parse(respGetBody.updated_at)).not.toBeNaN();
+    });
+
+    test("With case mismatch", async () => {
+      await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "CaseDiferente",
+          email: "CaseDiferente@curso.dev",
+          password: "123456",
+        }),
+      });
+
+      const respGet = await fetch(
+        "http://localhost:3000/api/v1/users/casediferente",
+      );
+      expect(respGet.status).toBe(200);
+
+      const respGetBody = await respGet.json();
+      expect(respGetBody).toEqual({
+        id: respGetBody.id,
+        username: "CaseDiferente",
+        email: "CaseDiferente@curso.dev",
+        password: "123456",
+        created_at: respGetBody.created_at,
+        updated_at: respGetBody.updated_at,
+      });
+      expect(uuidVersion(respGetBody.id)).toBe(4);
+      expect(Date.parse(respGetBody.created_at)).not.toBeNaN();
+      expect(Date.parse(respGetBody.updated_at)).not.toBeNaN();
+    });
+
+    test("With nonexistent username", async () => {
+      const resp = await fetch(
+        "http://localhost:3000/api/v1/users/UsuarioInexistente",
+      );
+      expect(resp.status).toBe(404);
+
+      const respBody = await resp.json();
+      expect(respBody).toEqual({
+        name: "NotFoundError",
+        message: "O username informado não foi encontrado no sistema.",
+        action: "Verifique se o username está digitado corretamente.",
+        status_code: 404,
+      });
+    });
+  });
+});

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -1,0 +1,118 @@
+import { version as uuidVersion } from "uuid";
+import orchestrator from "tests/orchestrator.js";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.clearDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("POST /api/v1/users", () => {
+  describe("Anonymous user", () => {
+    test("With unique and valid data", async () => {
+      const resp = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "gabynk",
+          email: "gaby@curso.dev",
+          password: "123456",
+        }),
+      });
+      expect(resp.status).toBe(201);
+
+      const respBody = await resp.json();
+      expect(respBody).toEqual({
+        id: respBody.id,
+        username: "gabynk",
+        email: "gaby@curso.dev",
+        password: "123456",
+        created_at: respBody.created_at,
+        updated_at: respBody.updated_at,
+      });
+      expect(uuidVersion(respBody.id)).toBe(4);
+      expect(Date.parse(respBody.created_at)).not.toBeNaN();
+      expect(Date.parse(respBody.updated_at)).not.toBeNaN();
+    });
+
+    test("With duplicated 'email'", async () => {
+      const respWithSuccess = await fetch(
+        "http://localhost:3000/api/v1/users",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            username: "duplicatedEmail",
+            email: "duplicateEmail@curso.dev",
+            password: "123456",
+          }),
+        },
+      );
+      expect(respWithSuccess.status).toBe(201);
+
+      const respWithError = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "duplicatedEmail2",
+          email: "DuplicateEmail@curso.dev",
+          password: "123456",
+        }),
+      });
+      expect(respWithError.status).toBe(400);
+
+      const respWithErrorBody = await respWithError.json();
+      expect(respWithErrorBody).toEqual({
+        name: "ValidationError",
+        message: "O email informado já está sendo utilizado.",
+        action: "Utilize outro email para realizar o cadastro.",
+        status_code: 400,
+      });
+    });
+
+    test("With duplicated 'username'", async () => {
+      const respWithSuccess = await fetch(
+        "http://localhost:3000/api/v1/users",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            username: "duplicatedUsername",
+            email: "duplicateUsername@curso.dev",
+            password: "123456",
+          }),
+        },
+      );
+      expect(respWithSuccess.status).toBe(201);
+
+      const respWithError = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: "DuplicatedUsername",
+          email: "duplicatedUsername2@curso.dev",
+          password: "123456",
+        }),
+      });
+      expect(respWithError.status).toBe(400);
+
+      const respWithErrorBody = await respWithError.json();
+      expect(respWithErrorBody).toEqual({
+        name: "ValidationError",
+        message: "O username informado já está sendo utilizado.",
+        action: "Utilize outro username para realizar o cadastro.",
+        status_code: 400,
+      });
+    });
+  });
+});

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -1,5 +1,6 @@
 import retry from "async-retry";
 import database from "infra/database";
+import migrator from "models/migrator";
 
 async function waitForAllServices() {
   await waitForWebServer();
@@ -24,8 +25,13 @@ async function clearDatabase() {
   await database.query("drop schema public cascade; create schema public;");
 }
 
+async function runPendingMigrations() {
+  await migrator.runPendingMigrations();
+}
+
 const orchestrator = {
   waitForAllServices,
   clearDatabase,
+  runPendingMigrations,
 };
 export default orchestrator;


### PR DESCRIPTION
- Cria model `user`
- Cria 2 novos endpoints:
   - `POST` `/api/v1/users`
   - `GET` `/api/v1/users/[username]`
- Remove `migration` de teste
- Cria `migration` que cria a tabela `users`
- Cria dois novos erros customizados:
   - `ValidationError`
   - `NotFoundError`
- Adiciona novo método ao `orchestrator`:
   - `runPendingMigrations`
- Silencia os logs do `migrator`